### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: bionic
 python:
   - 3.5
   - 3.6

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from bokeh.models import ColumnDataSource, Div, TextInput, Tabs, Panel, TapTool,
 from bokeh.palettes import Spectral10, Turbo256, linear_palette
 from bokeh.plotting import curdoc, gmap
 from bokeh.transform import log_cmap
-from fuzzywuzzy import process
+from rapidfuzz import process
 from matplotlib.dates import date2num
 from sklearn.cluster import DBSCAN
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cffi==1.13.2
 chardet==3.0.4
 cycler==0.10.0
 enum34==1.1.6
-fuzzywuzzy==0.18.0
+rapidfuzz==0.3.0
 h5py==2.10.0
 idna==2.8
 importlib-metadata==1.4.0
@@ -30,7 +30,6 @@ pycparser==2.19
 pyparsing==2.4.6
 pytest==5.3.3
 python-dateutil==2.8.1
-python-Levenshtein==0.12.0
 pytz==2019.3
 PyYAML==5.3
 requests==2.22.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy